### PR TITLE
Fix:($headers) could not be passed by reference

### DIFF
--- a/src/SignInWithAppleProvider.php
+++ b/src/SignInWithAppleProvider.php
@@ -10,6 +10,7 @@ use Laravel\Socialite\Two\ProviderInterface;
 use Laravel\Socialite\Two\User;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Nerdzlab\SocialiteAppleSignIn\Exceptions\AppleSignInException;
 use Throwable;
 
@@ -75,8 +76,7 @@ class SignInWithAppleProvider extends AbstractProvider implements ProviderInterf
         try {
             $payload = JWT::decode(
                 $token,
-                $this->getPublicKey($this->extractKid($token)),
-                [self::ALGORITHM]
+                new Key($this->getPublicKey($this->extractKid($token)), self::ALGORITHM),
             );
         } catch (Throwable $exception) {
             throw AppleSignInException::invalidToken($exception);


### PR DESCRIPTION
I was getting the error :

Firebase\JWT\JWT::decode(): Argument #3 ($headers) could not be passed by reference